### PR TITLE
Bugfix va arg

### DIFF
--- a/src/spe_printf.c
+++ b/src/spe_printf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2019 Stefan Petersen, Ciellt AB
+ * Copyright (c) 2013-2020 Stefan Petersen, Ciellt AB
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/src/spe_printf.c
+++ b/src/spe_printf.c
@@ -133,7 +133,6 @@ print_uil(SPE_FILE *fd, unsigned long number, const int base,
           int min_width, const int precision, int neg)
 {
     unsigned long divider = 1UL;
-    unsigned long digit = 0UL;
     int nuf_digits = 1;
 
     /* Find the biggest number dividable by base to use as starting
@@ -175,7 +174,7 @@ print_uil(SPE_FILE *fd, unsigned long number, const int base,
     /* Print out character by character by using the divider we just found. */
     /* This is the secret sauce to this no-buffering print routine. */
     while (1) {
-        digit = number / divider;
+        unsigned long digit = number / divider;
         print_char(fd, tohex[digit]);
         number = number - (digit * divider);
         divider /= (unsigned long)base;
@@ -241,7 +240,6 @@ print_ui(SPE_FILE *fd, unsigned int number, int base,
          int min_width, int precision, int neg)
 {
     unsigned long divider = 1UL;
-    unsigned long digit = 0UL;
     int nuf_digits = 1;
 
     /* Find the biggest number dividable by base to use as starting
@@ -283,7 +281,7 @@ print_ui(SPE_FILE *fd, unsigned int number, int base,
     /* Print out character by character by using the divider we just found. */
     /* This is the secret sauce to this no-buffering print routine. */
     while (1) {
-        digit = number / divider;
+        unsigned long digit = number / divider;
         print_char(fd, tohex[digit]);
         number = number - (unsigned int)(digit * divider);
         divider /= (unsigned long)base;

--- a/src/spe_printf.h
+++ b/src/spe_printf.h
@@ -24,6 +24,10 @@
 #ifndef SPE_PRINTF_H
 #define SPE_PRINTF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* For the variadic versions of the functions. */
 #include <stdarg.h>
 
@@ -96,5 +100,9 @@ int spe_snprintf(char *str, const size_t size, const char *fmt, ...);
 int spe_vfprintf(SPE_FILE *fd, const char *fmt, const va_list ap);
 int spe_vprintf(const char *fmt, const va_list ap);
 int spe_vsnprintf(char *str, const size_t size, const char *fmt, const va_list ap);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SPE_PRINTF_H */

--- a/src/spe_printf.h
+++ b/src/spe_printf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2019 Stefan Petersen, Ciellt AB
+ * Copyright (c) 2013-2020 Stefan Petersen, Ciellt AB
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/src/spe_printf.h
+++ b/src/spe_printf.h
@@ -97,9 +97,9 @@ extern SPE_FILE *spe_stderr;
 int spe_fprintf(SPE_FILE *fd, const char *fmt, ...);
 int spe_printf(const char *fmt, ...);
 int spe_snprintf(char *str, const size_t size, const char *fmt, ...);
-int spe_vfprintf(SPE_FILE *fd, const char *fmt, const va_list ap);
-int spe_vprintf(const char *fmt, const va_list ap);
-int spe_vsnprintf(char *str, const size_t size, const char *fmt, const va_list ap);
+int spe_vfprintf(SPE_FILE *fd, const char *fmt, va_list ap);
+int spe_vprintf(const char *fmt, va_list ap);
+int spe_vsnprintf(char *str, const size_t size, const char *fmt, va_list ap);
 
 #ifdef __cplusplus
 }

--- a/tests/AllTests/spe_printfTest.cpp
+++ b/tests/AllTests/spe_printfTest.cpp
@@ -85,6 +85,13 @@ TEST(spe_printf, HexIntegers)
 }
 
 /* Not supported by libc printf */
+TEST(spe_printf, NewTest)
+{
+    LONGS_EQUAL(0, spe_printf("k%u,%u", 1,2));
+    STRCMP_EQUAL("k1,2", output_mock_get_string());
+}
+
+/* Not supported by libc printf */
 TEST(spe_printf, BinaryIntegers)
 {
     spe_printf("%16.16b", 0x0f0f);
@@ -142,6 +149,11 @@ TEST(spe_printf, PositivAndNegativeDouble)
 TEST(spe_printf, SmallDecimalDouble)
 {
     do_comparison("[%f] and [%7.2f]", 12.0034, -43.21);
+}
+
+TEST(spe_printf, SeveralCharacters)
+{
+    do_comparison("%u,%u", 1, 2);
 }
 
 TEST(spe_printf, snprintfFirstTest)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -41,7 +41,8 @@ TOPDIR = $(shell dirname `pwd`)
 
 CPPUTEST_USE_EXTENSIONS = Y
 CPPUTEST_WARNINGFLAGS =  -Wall -Wextra -Werror -Wshadow -Wswitch-default -Wswitch-enum -Wcast-qual -Wsign-compare -Wconversion
-CPPUTEST_ADDITIONAL_CFLAGS = -DUSE_DOUBLE
+CPPUTEST_CFLAGS = -DUSE_DOUBLE -O3
+CPPUTEST_CPPFLAGS = $(CPPUTEST_CFLAGS)
 CPPUTEST_LDFLAGS = -lm
 
 CPP_PLATFORM = Gcc


### PR DESCRIPTION
VA arg did not work the same way on Cortex-M as on X86-64 Linux. It must be a pointer and it must _not_ be const. Hopefully this will make it work on both platforms.