### PR TITLE
Use format attribute to check function parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It supports:
 * minimal width and optional precision for all numerical types.
 * long modifier.
 * plain percent (%), character (c), string (s), signed integer, 
-  unsigned integer(u), hex (x) and binary (b).
+  unsigned integer(u) and hex (x).
 * double if compiled in, see below.
 * Includes variadic versions of all printf() functions.
 * Includes snprintf()/vsnprintf() versions to print to strings.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Supported conversion tags
 ==
 It supports:
 * minimal width and optional precision for all numerical types.
-* long modifier.
+* long modifier for all numerical conversion tags.
 * plain percent (%), character (c), string (s), signed integer, 
   unsigned integer(u) and hex (x).
 * double if compiled in, see below.

--- a/src/spe_printf.c
+++ b/src/spe_printf.c
@@ -56,8 +56,8 @@
  *
  * \subsection conversion_tags_optional Optional
  *
- * The `l` modifier can be used with signed and unsigned conversion tags
- * print out `long` variables (`%%lu` and `%%ld`).
+ * The `l` modifier can be used with signed, unsigned and hexadecimal
+ * conversion tags to print out `long` variables (`%%lu`, `%%ld` and `%%lx`).
  *
  * \section printf_variants Variants of the printf routines
  *
@@ -478,7 +478,13 @@ conversion(SPE_FILE *fd, const char *fmt, int i, const va_list *ap)
             }
             return i;
         case 'x': /* Hex */
-            print_ui(fd, va_arg(*ap, unsigned int), 16, min_width, precision, 0);
+            if (long_modifier) {
+                print_uil(fd, va_arg(*ap, unsigned long), 16, min_width,
+                          precision, 0);
+            } else {
+                print_ui(fd, va_arg(*ap, unsigned int), 16, min_width,
+                         precision, 0);
+            }
             return i;
 #ifdef USE_DOUBLE
         case 'f':

--- a/src/spe_printf.c
+++ b/src/spe_printf.c
@@ -51,7 +51,6 @@
  * \li d: prints out a signed integer variable in decimal format.
  * \li u: prints out an unsigned integer variable in decimal format.
  * \li x: prints out an unsigned integer variable in hexadecimal format.
- * \li b: prints out an unsigned integer variable in binary format.
  * \li f: prints out floating point number, if compiled in. Compile with
  * ``CFLAGS += -DUSE_DOUBLE`` as argument to compiler.
  *
@@ -480,9 +479,6 @@ conversion(SPE_FILE *fd, const char *fmt, int i, const va_list *ap)
             return i;
         case 'x': /* Hex */
             print_ui(fd, va_arg(*ap, unsigned int), 16, min_width, precision, 0);
-            return i;
-        case 'b': /* Binary */
-            print_ui(fd, va_arg(*ap, unsigned int), 2, min_width, precision, 0);
             return i;
 #ifdef USE_DOUBLE
         case 'f':

--- a/src/spe_printf.h
+++ b/src/spe_printf.h
@@ -90,7 +90,6 @@ extern SPE_FILE *spe_stderr;
  * 'u': Unsigned integer and long
  * 'l': long modifier, used with u and d
  * 'x': Hex, takes unsigned integer
- * 'b': Binary, takes unsigned integer
  * 'f': Double, floating point, if support is compiled in
  */
 

--- a/src/spe_printf.h
+++ b/src/spe_printf.h
@@ -94,12 +94,18 @@ extern SPE_FILE *spe_stderr;
  * 'f': Double, floating point, if support is compiled in
  */
 
-int spe_fprintf(SPE_FILE *fd, const char *fmt, ...);
-int spe_printf(const char *fmt, ...);
-int spe_snprintf(char *str, const size_t size, const char *fmt, ...);
-int spe_vfprintf(SPE_FILE *fd, const char *fmt, va_list ap);
-int spe_vprintf(const char *fmt, va_list ap);
-int spe_vsnprintf(char *str, const size_t size, const char *fmt, va_list ap);
+int spe_fprintf(SPE_FILE *fd, const char *fmt, ...)
+    __attribute__((__format__(__printf__, 2, 3)));
+int spe_printf(const char *fmt, ...)
+    __attribute__((__format__(__printf__, 1, 2)));
+int spe_snprintf(char *str, const size_t size, const char *fmt, ...)
+    __attribute__((__format__(__printf__, 3, 4)));
+int spe_vfprintf(SPE_FILE *fd, const char *fmt, va_list ap)
+    __attribute__((__format__(__printf__, 2, 0)));
+int spe_vprintf(const char *fmt, va_list ap)
+    __attribute__((__format__(__printf__, 1, 0)));
+int spe_vsnprintf(char *str, const size_t size, const char *fmt, va_list ap)
+    __attribute__((__format__(__printf__, 3, 0)));
 
 #ifdef __cplusplus
 }

--- a/tests/AllTests/spe_printfTest.cpp
+++ b/tests/AllTests/spe_printfTest.cpp
@@ -91,13 +91,6 @@ TEST(spe_printf, NewTest)
     STRCMP_EQUAL("k1,2", output_mock_get_string());
 }
 
-/* Not supported by libc printf */
-TEST(spe_printf, BinaryIntegers)
-{
-    spe_printf("%16.16b", 0x0f0f);
-    STRCMP_EQUAL("0000111100001111", output_mock_get_string());
-}
-
 TEST(spe_printf, Characters)
 {
     do_comparison("Character %c\n", 'c');


### PR DESCRIPTION
Add the GNU/GCC format attributes to spe_printf et al. Then the compiler can do format checking when compiling. 
Closes #12 .