### PR TITLE
Remove trunc dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,7 @@ It does not support:
 double()
 ==
 It can print doubles too. Then the variable USE_DOUBLE needs to be set
-when compiling, by for instance adding *CFLAGS+=-DUSE_DOUBLE* in the Makefile.
-When including usage of double, math.h and math lib is necessary. Using just
-casting to change one part (integer or decimal) of the double to an int lost
-too much precision. So by using truncf() instead I managed to get better
-precision, especially in the decimal part.
+when compiling, by for instance adding `CFLAGS+=-DUSE_DOUBLE` in the Makefile.
 
 Documentation
 ==

--- a/src/Doxyfile
+++ b/src/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = docs
+OUTPUT_DIRECTORY       = doxygen
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,6 @@
 
 CC=gcc
 CFLAGS=-Wall -Wextra -DUSE_DOUBLE -std=c99
-LDLIBS=-lm
 
 CPPCHECK_TESTS = "--enable=warning,style,performance,portability"
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2019 Stefan Petersen, Ciellt AB
+# Copyright (c) 2013-2021 Stefan Petersen, Ciellt AB
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/src/spe_printf.c
+++ b/src/spe_printf.c
@@ -91,10 +91,6 @@
 
 #include "spe_printf.h"
 
-#ifdef USE_DOUBLE
-#include <math.h>
-#endif /* USE_DOUBLE */
-
 static const char tohex_lc[] = "0123456789abcdef";
 static const char tohex_uc[] = "0123456789ABCDEF";
 
@@ -385,7 +381,7 @@ print_d(SPE_FILE *fd, double fp, int min_width, int precision)
 
     /* Split double into integer integer and integer decimal */
     ii = (unsigned int)fp;
-    tmp = fp  * pm - trunc(fp) * pm;
+    tmp = fp  * pm - (int)fp * pm;
     id = (unsigned int)tmp;
 
     /* Punctuation is included in the min_width */

--- a/src/spe_printf.c
+++ b/src/spe_printf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020 Stefan Petersen, Ciellt AB
+ * Copyright (c) 2013-2021 Stefan Petersen, Ciellt AB
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/AllTests/spe_printfTest.cpp
+++ b/tests/AllTests/spe_printfTest.cpp
@@ -149,6 +149,11 @@ TEST(spe_printf, SmallDecimalDouble)
     do_comparison("[%f] and [%7.2f]", 12.0034, -43.21);
 }
 
+TEST(spe_printf, BigDecimalDouble)
+{
+    do_comparison("[%f] and [%7.2f]", 12.9999, -43.98);
+}
+
 TEST(spe_printf, SeveralCharacters)
 {
     do_comparison("%u,%u", 1, 2);

--- a/tests/AllTests/spe_printfTest.cpp
+++ b/tests/AllTests/spe_printfTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2019 Stefan Petersen, Ciellt AB
+ * Copyright (c) 2013-2021 Stefan Petersen, Ciellt AB
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2019 Stefan Petersen, Ciellt AB
+# Copyright (c) 2013-2021 Stefan Petersen, Ciellt AB
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -43,7 +43,6 @@ CPPUTEST_USE_EXTENSIONS = Y
 CPPUTEST_WARNINGFLAGS =  -Wall -Wextra -Werror -Wshadow -Wswitch-default -Wswitch-enum -Wcast-qual -Wsign-compare -Wconversion
 CPPUTEST_CFLAGS = -DUSE_DOUBLE -O3
 CPPUTEST_CPPFLAGS = $(CPPUTEST_CFLAGS)
-CPPUTEST_LDFLAGS = -lm
 
 CPP_PLATFORM = Gcc
 


### PR DESCRIPTION
Remove dependency of `trunc()`, spe_printf seems to work fine without it. Removes requirement on `math.h` and no need to link with `-lm` anymore.